### PR TITLE
Use $more_link_text instead of the custom text

### DIFF
--- a/index.php
+++ b/index.php
@@ -102,7 +102,7 @@
                         if ( is_archive() || is_search() ){
                             the_excerpt();
                         } else {
-                            the_content( __('Read more about it..','tiny') );
+                            the_content( __($more_link_text,'tiny') );
                         }
                         edit_post_link(__('Edit','tiny'));
                         ?>


### PR DESCRIPTION
By using the Core function/variable $more_link_text, the "Read more"
text after an excerpt is shown/rendered in the proper language on
non-english WordPress installations.